### PR TITLE
this change removes hardcodeing of the pmem patch.

### DIFF
--- a/roles/upgrade-libvirt-qemu/tasks/main.yaml
+++ b/roles/upgrade-libvirt-qemu/tasks/main.yaml
@@ -102,10 +102,10 @@
   become: true
   become_user: stack
 
-- name: apply vpmem patch
-  shell: cd /opt/stack/nova && git fetch https://review.opendev.org/openstack/nova refs/changes/70/678470/13 && git checkout FETCH_HEAD && git checkout -b vpmem
-  become: true
-  become_user: stack
+#- name: apply vpmem patch
+#  shell: cd /opt/stack/nova && git fetch https://review.opendev.org/openstack/nova refs/changes/70/678470/13 && git checkout FETCH_HEAD && git checkout -b vpmem
+#  become: true
+#  become_user: stack
 
 - name: upgrade DB
   shell: nova-manage  --config-file /etc/nova/nova_cell1.conf  db sync  --local_cell


### PR DESCRIPTION
i think there is a seperate fix for this internally that is pending but i want to test if you have zuulv3 configured to support depend-on with pull request which should work to allow us to work around these types of issues upstream 